### PR TITLE
BirthdayToAgeConverter : Use Math.Floor instead of Math.Round

### DIFF
--- a/BindingsAndConverters/Converters/BirthdateToAgeConverter.cs
+++ b/BindingsAndConverters/Converters/BirthdateToAgeConverter.cs
@@ -17,7 +17,7 @@ public class BirthdateToAgeConverter : IValueConverter
 
         var diff = DateTimeOffset.Now - ageDto;
         
-        var age = (int)Math.Round(diff.TotalDays / 365);
+        var age = (int)Math.Floor(diff.TotalDays / 365);
 
         return age >= 0 ? age : 0;
     }


### PR DESCRIPTION
Round will convert age to 1 if you are 7 months old. Floor will only convert your age when you reach your birthday.